### PR TITLE
Rename output variable and add Docker cleanup

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -3,14 +3,16 @@ description: 'Checks out branch of PR/Push action'
 outputs:
   branch-name:
     description: "Branch Name"
-    value: ${{ steps.branch.outputs.branch-name }}
+    value: ${{ steps.branch.outputs.branch }}
 runs:
   using: "composite"
   steps:
     - name: Extract branch name
-      shell: bash
-      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
       id: branch
+      shell: bash
+      run: |
+        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        docker stop $(docker ps -aq) && docker rm -f $(docker ps -aq)
     - name: Checking out branch ${{ steps.branch.outputs.branch }}
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Renamed the output variable `branch-name` to `branch` in action.yaml. Added a command to stop and remove all Docker containers after extracting the branch name, while keeping the original extraction command intact.