### PR TITLE
Add Docker cleanup step and branch checkout update

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -10,9 +10,16 @@ runs:
     - name: Extract branch name
       id: branch
       shell: bash
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+
+    - name: Cleanup Docker containers
+      if: always()
+      shell: bash
       run: |
-        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        docker stop $(docker ps -aq) && docker rm -f $(docker ps -aq)
+        docker stop $(docker ps -aq) || true
+        docker rm -f $(docker ps -aq) || true
+      continue-on-error: true
+     
     - name: Checking out branch ${{ steps.branch.outputs.branch }}
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This commit introduces a new step in `action.yaml` for cleaning up Docker containers, which runs regardless of previous step outcomes. The cleanup commands are modified to prevent workflow failure by using `|| true`. Additionally, the branch name extraction output is now utilized in the checkout step to ensure the correct branch is checked out.